### PR TITLE
Added Vehicle component, updated getData to accept a URL

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -45,6 +45,11 @@ gulp.task('server:watch', function () {
     gulp.watch( [ './server.js' ], server.restart );
 });
 
+gulp.task('images', function() {
+    gulp.src(['images/**/*.{gif,jpg,png,svg}'])
+        .pipe(gulp.dest('dist/images'));
+  });
+
 gulp.task('default', function () {
-  gulp.start('sass', 'sass:watch', 'js', 'js:watch', 'server', 'server:watch');
+  gulp.start('sass', 'sass:watch', 'images', 'js', 'js:watch', 'server', 'server:watch');
 });

--- a/src/api/index.js
+++ b/src/api/index.js
@@ -3,17 +3,17 @@
 * handling asynchronous data fetching
 **/
 
-export const getData = (cb) => {
-    const vehicles = new XMLHttpRequest();
-    vehicles.open('GET', 'http://localhost:9988/api/vehicle');
+export const getData = (url, cb) => {
+    const request = new XMLHttpRequest();
+    request.open('GET', 'http://localhost:9988' + url);
 
-    vehicles.onreadystatechange = function() {
-        if(vehicles.readyState === 4) {
- 		    if(vehicles.status === 200) {
- 			    cb(vehicles.responseText);
-		    }
+    request.onreadystatechange = function() {
+        if(request.readyState === 4) {
+			if(request.status === 200) {
+				cb(JSON.parse(request.responseText));
+			}
 		}
 	};
 
-	vehicles.send();
+	request.send();
 };

--- a/src/components/Vehicle.js
+++ b/src/components/Vehicle.js
@@ -1,0 +1,29 @@
+import React, { Component } from 'react';
+import { getData } from '../api';
+
+export class Vehicle extends Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            vehicle: props.data
+        };
+    }
+
+    componentDidMount() {
+        getData(this.state.vehicle.url, (data) => {
+            this.setState({ vehicle: Object.assign(this.state.vehicle, data) });
+		});
+    }
+
+	render() {
+        return (
+            <div className="c-vehicle">
+                <img className="c-vehicle__image"src={this.state.vehicle.media[0].url} />
+                <h2 className="c-vehicle__title">{this.state.vehicle.id}</h2>
+                <h3 className="c-vehicle__price">From {this.state.vehicle.price}</h3>
+                <p className="c-vehicle__description">{this.state.vehicle.description}</p>
+            </div>
+        );
+	}
+}

--- a/src/components/VehicleList.js
+++ b/src/components/VehicleList.js
@@ -1,8 +1,8 @@
 import React, { Component } from 'react';
 import { getData } from '../api';
+import { Vehicle } from './Vehicle';
 
-export default
-class VehicleList extends Component {
+export default class VehicleList extends Component {
 
 	constructor(props) {
 		super(props);
@@ -13,19 +13,18 @@ class VehicleList extends Component {
 	}
 
 	componentDidMount() {
-		getData((data) => {
-			this.setState({
-				data
-			})
+		getData("/api/vehicle", (data) => {
+			this.setState({data})
 		});
 	}
 
 	render() {
 		if(this.state.data) {
-			console.log(this.state.data);
 		    return (
-			    <h1>Hello World</h1>
-		    )
+				<div className="c-vehicle-list">
+					{this.state.data.vehicles.map(data => <Vehicle data={data} />)}
+				</div>
+			)
 	    }
 
 		return (<h1>Loading...</h1>);

--- a/src/style.scss
+++ b/src/style.scss
@@ -1,5 +1,41 @@
-$bg-colour: #ccc;
+$bg-colour: white;
+$border-color: #c1c1c1;
+$global-padding: 10px;
+$global-font: 'Roboto', sans-serif;
 
 body {
 	background-color: $bg-colour;
+	font-family: $global-font;
+}
+
+.c-vehicle-list {
+	display: grid;
+	grid-template-columns: repeat(1, 1fr);
+	grid-column-gap: $global-padding;
+	grid-row-gap: $global-padding;
+
+	.c-vehicle {
+		border: 1px solid $border-color;
+		padding: $global-padding;
+
+		&__title {
+			text-transform: uppercase;
+		}
+
+		&__image {
+			width: 100%;
+		}
+	}
+
+	@media screen and (min-width: 1200px) {
+		grid-template-columns: repeat(4, 1fr);
+	}
+
+	@media screen and (min-width: 1080px) and (max-width: 1199px) {
+		grid-template-columns: repeat(3, 1fr);
+	}
+
+	@media screen and (min-width: 640px) and (max-width: 1079px) {
+		grid-template-columns: repeat(2, 1fr);
+	}
 }

--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -5,14 +5,13 @@ const expect = require('chai').expect;
 const getData = require('../src/api').getData;
 const server = require('../server');
 
-describe("getData example test", function() {
+describe("getData example test", () => {
     beforeEach(() => {
         server.listen(9988);
     });
 
-    it('should respond with an array of vehicles', (done) => {
-        getData((response) => {
-            const data = JSON.parse(response);
+    it('should respond with an array of vehicles', done => {
+        getData("/api/vehicle", data => {
             expect(Array.isArray(data.vehicles)).to.equal(true);
             done();
         })

--- a/test/vehicle.spec.js
+++ b/test/vehicle.spec.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ReactDOM from 'react-dom';
+import { Vehicle } from '../src/components/Vehicle';
+
+const expect = require('chai').expect;
+
+describe("Vehicle component", function() {
+    const mockData = {
+        id: "Foo",
+        price: "£30,000",
+        description: "This is a test",
+        media: [
+            { 
+                url: "/path/to/media"
+            }
+        ]
+    };
+
+    it('should render correctly', () => {
+        const wrapper = shallow(<Vehicle data={mockData} />);
+
+        expect(wrapper.text().includes('Foo')).to.be.true;
+        expect(wrapper.text().includes('£30,000')).to.be.true;
+        expect(wrapper.text().includes('This is a test')).to.be.true;
+    })
+});

--- a/views/index.html
+++ b/views/index.html
@@ -3,9 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <title>Title</title>
+    <title>Connect Test</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=0" />
     <link href="/style.css" rel="stylesheet" type="text/css">
+    <link href="//fonts.googleapis.com/css?family=Roboto&display=swap" rel="stylesheet">
 </head>
 <body>
 <div id="app"></div>


### PR DESCRIPTION
This PR demonstrates a really basic feature that adds a new `Vehicle` component, which uses the `getData` function to fetch data from the `vehicles` API. The functionality has broken backwards compatibility but allows multiple URLs to be called without having to add another wrapper function around `XMLHttpRequest`.

Basic styling has been added to adhere to the design. `sass` has been used, 3 new variables have been added which can be reused. By design, mobile is default and media queries have been added to support larger resolutions. Anything on desktop will show up to 4 cars within a row, tablets will show 2 and mobile shows 1. `grid` has been used because of simplicity and support by major browsers.

To summarize:

- Added basic `Vehicle` component which is tested using `enzyme`
- Maintaining node 6 version (although out of date and no longer supported)
- `gulp` command updatedto copy images into `dist` folder
- Tests added / updated
- Styles included using grid (supported by IE11+, Firefox, Chrome and Safari)